### PR TITLE
Add Mono.Linq.Expressions-Android project.

### DIFF
--- a/Expressions.projitems
+++ b/Expressions.projitems
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>{B0E0CA1A-3327-4A4E-910D-0B2B9EA7A61E}</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Expressions</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\CombineExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\CSharp.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\CSharpWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\CustomExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\CustomExpressionVisitor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\DelegateConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\DoWhileExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\ExpressionExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\ExpressionWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\FluentExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\ForEachExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\ForExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\IExpressionWriter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\IFormatter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\PredicateBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\TextFormatter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\UsingExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Mono.Linq.Expressions\WhileExpression.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+</Project>

--- a/Expressions.shproj
+++ b/Expressions.shproj
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectGuid>{B0E0CA1A-3327-4A4E-910D-0B2B9EA7A61E}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <Import Project="Expressions.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/Mono.Linq.Expressions-Android/Mono.Linq.Expressions-Android.csproj
+++ b/Mono.Linq.Expressions-Android/Mono.Linq.Expressions-Android.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Mono.Linq.Expressions</RootNamespace>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AssemblyName>Mono.Linq.Expressions</AssemblyName>
+    <TargetFrameworkVersion>v1.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Android" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Resources\Resource.designer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AboutResources.txt" />
+  </ItemGroup>
+  <Import Project="..\Expressions.projitems" Label="Shared" Condition="Exists('..\Expressions.projitems')" />
+  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+</Project>

--- a/Mono.Linq.Expressions-Android/Resources/AboutResources.txt
+++ b/Mono.Linq.Expressions-Android/Resources/AboutResources.txt
@@ -1,0 +1,44 @@
+Images, layout descriptions, binary blobs and string dictionaries can be included 
+in your application as resource files.  Various Android APIs are designed to 
+operate on the resource IDs instead of dealing with images, strings or binary blobs 
+directly.
+
+For example, a sample Android app that contains a user interface layout (main.axml),
+an internationalization string table (strings.xml) and some icons (drawable-XXX/icon.png) 
+would keep its resources in the "Resources" directory of the application:
+
+Resources/
+    drawable/
+        icon.png
+
+    layout/
+        main.axml
+
+    values/
+        strings.xml
+
+In order to get the build system to recognize Android resources, set the build action to
+"AndroidResource".  The native Android APIs do not operate directly with filenames, but 
+instead operate on resource IDs.  When you compile an Android application that uses resources, 
+the build system will package the resources for distribution and generate a class called "R" 
+(this is an Android convention) that contains the tokens for each one of the resources 
+included. For example, for the above Resources layout, this is what the R class would expose:
+
+public class R {
+    public class drawable {
+        public const int icon = 0x123;
+    }
+
+    public class layout {
+        public const int main = 0x456;
+    }
+
+    public class strings {
+        public const int first_string = 0xabc;
+        public const int second_string = 0xbcd;
+    }
+}
+
+You would then use R.drawable.icon to reference the drawable/icon.png file, or R.layout.main 
+to reference the layout/main.axml file, or R.strings.first_string to reference the first 
+string in the dictionary file values/strings.xml.

--- a/Mono.Linq.Expressions.csproj
+++ b/Mono.Linq.Expressions.csproj
@@ -61,27 +61,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Mono.Linq.Expressions\CombineExtensions.cs" />
-    <Compile Include="Mono.Linq.Expressions\DoWhileExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\FluentExtensions.cs" />
-    <Compile Include="Mono.Linq.Expressions\UsingExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\WhileExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\CustomExpressionVisitor.cs" />
-    <Compile Include="Mono.Linq.Expressions\CustomExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\ForEachExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\ForExpression.cs" />
-    <Compile Include="Mono.Linq.Expressions\PredicateBuilder.cs" />
-    <Compile Include="Mono.Linq.Expressions\ExpressionExtensions.cs" />
-    <Compile Include="Mono.Linq.Expressions\CSharp.cs" />
-    <Compile Include="Mono.Linq.Expressions\CSharpWriter.cs" />
-    <Compile Include="Mono.Linq.Expressions\ExpressionWriter.cs" />
-    <Compile Include="Mono.Linq.Expressions\IExpressionWriter.cs" />
-    <Compile Include="Mono.Linq.Expressions\DelegateConverter.cs" />
-    <Compile Include="Mono.Linq.Expressions\IFormatter.cs" />
-    <Compile Include="Mono.Linq.Expressions\TextFormatter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="mono.snk" />
   </ItemGroup>
   <ItemGroup>
@@ -104,6 +83,7 @@
   <ItemGroup>
     <Content Include="nodes.txt" />
   </ItemGroup>
+  <Import Project="Expressions.projitems" Label="Shared" Condition="Exists('Expressions.projitems')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Exec Command="&quot;$(MSBuildProjectPath)tools\patch-constraints.exe&quot; &quot;$(MSBuildProjectPath)@(MainAssembly)&quot; &quot;$(MSBuildProjectPath)$(AssemblyOriginatorKeyFile)&quot;" />

--- a/Mono.Linq.Expressions.sln
+++ b/Mono.Linq.Expressions.sln
@@ -1,11 +1,15 @@
 
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Expressions", "Expressions.shproj", "{B0E0CA1A-3327-4A4E-910D-0B2B9EA7A61E}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linq.Expressions", "Mono.Linq.Expressions.csproj", "{0C001D50-4176-45AE-BDC8-BA626508B0CC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dbg", "dbg\dbg.csproj", "{A1939E56-E2B2-44CF-8B29-347E7EE459E0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linq.Expressions.Tests", "Test\Mono.Linq.Expressions.Tests.csproj", "{4F200EA1-EFDA-48BF-BAAA-FFD9DE9BCD8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mono.Linq.Expressions-Android", "Mono.Linq.Expressions-Android\Mono.Linq.Expressions-Android.csproj", "{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,6 +51,18 @@ Global
 		{4F200EA1-EFDA-48BF-BAAA-FFD9DE9BCD8F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{4F200EA1-EFDA-48BF-BAAA-FFD9DE9BCD8F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{4F200EA1-EFDA-48BF-BAAA-FFD9DE9BCD8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Debug|x86.Build.0 = Debug|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|x86.ActiveCfg = Release|Any CPU
+		{9ECA2816-41D2-4796-8CA2-758EDCFB5C68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
"Refactor" Mono.Linq.Expressions.csproj so that it uses
Expressions.projitems and Expressions.shproj, a Shared Project which
allows sharing source code between projects.

Add a Mono.Linq.Expressions-Android project, which builds the
Expressions shared project for use in Xamarin.Android apps.