### PR TITLE
Turn into a PCL Profile92 Project.

### DIFF
--- a/Mono.Linq.Expressions.csproj
+++ b/Mono.Linq.Expressions.csproj
@@ -6,10 +6,12 @@
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{0C001D50-4176-45AE-BDC8-BA626508B0CC}</ProjectGuid>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Mono.Linq.Expressions</RootNamespace>
     <AssemblyName>Mono.Linq.Expressions</AssemblyName>
+    <TargetFrameworkProfile>Profile92</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
@@ -104,7 +106,7 @@
   <ItemGroup>
     <Content Include="nodes.txt" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Exec Command="&quot;$(MSBuildProjectPath)tools\patch-constraints.exe&quot; &quot;$(MSBuildProjectPath)@(MainAssembly)&quot; &quot;$(MSBuildProjectPath)$(AssemblyOriginatorKeyFile)&quot;" />
   </Target>

--- a/Mono.Linq.Expressions/CSharpWriter.cs
+++ b/Mono.Linq.Expressions/CSharpWriter.cs
@@ -1132,7 +1132,7 @@ namespace Mono.Linq.Expressions {
 		{
 			Visit (Expression.Call (
 				node.Expression,
-				typeof (object).GetMethod ("GetType", Type.EmptyTypes)));
+				typeof (object).GetMethod ("GetType", new Type [0])));
 
 			WriteSpace ();
 			WriteToken ("==");

--- a/Mono.Linq.Expressions/ForEachExpression.cs
+++ b/Mono.Linq.Expressions/ForEachExpression.cs
@@ -250,7 +250,7 @@ namespace Mono.Linq.Expressions {
 					Expression.Call (
 						disposable,
 						"Dispose",
-						Type.EmptyTypes)));
+						new Type [0])));
 		}
 
 		private bool TryGetGenericEnumerableArgument (out Type argument)


### PR DESCRIPTION
Allow easy use by Xamarin.Android and Xamarin.iOS by turning
Mono.Linq.Expressions into a Profile92 PCL library.

(Why Profile92? Because it required the fewest changes to support.)