### PR TITLE
Fix CSharpWriter.VisitNew() when invoking struct default constructor

### DIFF
--- a/Mono.Linq.Expressions/CSharpWriter.cs
+++ b/Mono.Linq.Expressions/CSharpWriter.cs
@@ -960,7 +960,7 @@ namespace Mono.Linq.Expressions {
 		{
 			WriteKeyword ("new");
 			WriteSpace ();
-			VisitType (node.Constructor.DeclaringType);
+			VisitType (node.Constructor == null ? node.Type : node.Constructor.DeclaringType);
 			VisitArguments (node.Arguments);
 
 			return node;

--- a/Test/Mono.Linq.Expressions/CSharpWriterTest.cs
+++ b/Test/Mono.Linq.Expressions/CSharpWriterTest.cs
@@ -537,6 +537,21 @@ int (int[] array)
 		}
 
 		[Test, MethodImpl (MethodImplOptions.NoInlining)]
+		public void NewStruct ()
+		{
+			var lambda = Expression.Lambda<Func<int>> (
+				Expression.New (
+					typeof (int)));
+
+			AssertExpression (@"
+int ()
+{
+	return new int();
+}
+", lambda);
+		}
+
+		[Test, MethodImpl (MethodImplOptions.NoInlining)]
 		public void NewArrayInit ()
 		{
 			var lambda = Expression.Lambda<Func<string []>> (


### PR DESCRIPTION
A value type's default constructor isn't returned by Reflection:

	csharp> typeof(int).GetConstructor(new Type[0]);
	null

Consequently, when using `Expression.New(typeof(int))` (or any other
value type), NewExpression.Constructor is null.

Consequently, the .ToCSharpCode() extension method blows up with a
NulLReferenceException should you try to use it:

	csharp> Expression<Func<int>> e = () => new int();
	csharp> e.ToCSharpCode();
	System.NullReferenceException: Object reference not set to an instance of an object
	  at Mono.Linq.Expressions.CSharpWriter.VisitNew (System.Linq.Expressions.NewExpression node)
	  ...

This is No Fun™.

Fix CSharpWriter.VisitNew() so that when NewExpression.Constructor is
null, we instead write out NewExpression.Type. This fixes the NRE.