### PR TITLE
Fix the Release configuration build on !Windows

### DIFF
--- a/Mono.Linq.Expressions.csproj
+++ b/Mono.Linq.Expressions.csproj
@@ -107,7 +107,5 @@
     <Content Include="nodes.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Target Name="AfterBuild" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Exec Command="&quot;$(MSBuildProjectPath)tools\patch-constraints.exe&quot; &quot;$(MSBuildProjectPath)@(MainAssembly)&quot; &quot;$(MSBuildProjectPath)$(AssemblyOriginatorKeyFile)&quot;" />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)Mono.Linq.Expressions.targets" />
 </Project>

--- a/Mono.Linq.Expressions.targets
+++ b/Mono.Linq.Expressions.targets
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ManagedRuntime Condition=" '$(ManagedRuntime)' == '' And '$(OS)' != 'Windows_NT' ">mono</ManagedRuntime>
+  </PropertyGroup>
+  <Target Name="AfterBuild"
+      Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Exec
+        Command="$(ManagedRuntime) &quot;$(MSBuildProjectPath)tools\patch-constraints.exe&quot; &quot;$(TargetPath)&quot; &quot;$(MSBuildProjectPath)$(AssemblyOriginatorKeyFile)&quot;" />
+  </Target>
+</Project>


### PR DESCRIPTION
The Release configuration on a non-Windows platform fails:

	Target AfterBuild:
		Executing: "tools/patch-constraints.exe" "" "mono.snk"
		/var/folders/1y/wwmg3hv5685ft661f5q2w2100000gn/T/tmp136e17d9.tmp: line 1: tools/patch-constraints.exe: cannot execute binary file
	.../mono.linq.expressions/Mono.Linq.Expressions.csproj: error : Command '"tools/patch-constraints.exe" "" "mono.snk"' exited with code: 126.

The `AfterBuild` target fails for two reasons:

1. `tools/patch-constraints.exe` isn't directly executable, and
2. The second argument -- the assembly to update -- is not provided.

Fix (1) by adding a new `$(ManagedRuntime)` property which defaults to
`mono` when running on non-Windows platforms.

Fix (2) by using `$(TargetPath)` instead of
`$(MSBuildProjectPath)@(MainAssembly)`, as `$(MSBuildProjectPath)` may
not be set (it's `""` in the above command ouptut) and
`@(MainAssembly)` doesn't exist.

Additionally, move the `AfterBuild` target into a new
`Mono.Linq.Expressions.targets` file so that the IDE won't attempt to
reformat the contents -- losing formatting information -- every time
the IDE attempts to save `Mono.Linq.Expressions.csproj`.